### PR TITLE
Fix kisekae modal checkboxes without unsupported arguments

### DIFF
--- a/python-app-local/editor_app.py
+++ b/python-app-local/editor_app.py
@@ -404,9 +404,22 @@ class KisekaePresetModal(ctk.CTkToplevel):
                 self.previews[effect.name] = ct_img
                 row = ctk.CTkFrame(tab)
                 row.pack(fill="x", padx=8, pady=6)
-                chk = ctk.CTkCheckBox(row, text=effect.display_name, image=ct_img, compound="left", variable=var,
-                                      command=self._propagate)
-                chk.pack(anchor="w", padx=6, pady=4)
+
+                content = ctk.CTkFrame(row)
+                content.pack(anchor="w", padx=6, pady=4, fill="x")
+
+                img_label = ctk.CTkLabel(content, image=ct_img, text="")
+                img_label.image = ct_img  # prevent GC
+                img_label.pack(side="left", padx=(0, 8))
+
+                chk = ctk.CTkCheckBox(content, text=effect.display_name, variable=var, command=self._propagate)
+                chk.pack(side="left")
+
+                def _toggle_and_propagate(v=var):
+                    v.set(not v.get())
+                    self._propagate()
+
+                img_label.bind("<Button-1>", lambda e, toggle=_toggle_and_propagate: toggle())
                 if effect.description:
                     ctk.CTkLabel(row, text=effect.description, justify="left", wraplength=320, anchor="w").pack(
                         anchor="w", padx=32, pady=(0, 6)


### PR DESCRIPTION
## Summary
- replace CTkCheckBox image usage in the kisekae modal with a label-plus-checkbox layout
- bind thumbnail clicks to toggle the associated checkbox while keeping previews alive

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_69043c3fa7a48321b17ee95d080aedd5